### PR TITLE
Add maintenance service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,6 +109,14 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "-e", "QUIT"]
+
+  maintenance:
+    build:
+      context: maintenance/
+    networks:
+      - webnet
+    environment:
+      - TIME=at the moment
     
 networks:
   webnet:

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -5,6 +5,5 @@ COPY ./entrypoint.sh .
 
 WORKDIR /home/static
 COPY ./static/ .
-RUN sed -i "s/{{TIME}}/$(echo ${TIME})/g" ./index.html
 
 ENTRYPOINT [ "sh", "/home/entrypoint.sh" ]

--- a/maintenance/Dockerfile
+++ b/maintenance/Dockerfile
@@ -1,0 +1,10 @@
+FROM busybox:musl
+
+WORKDIR /home/
+COPY ./entrypoint.sh .
+
+WORKDIR /home/static
+COPY ./static/ .
+RUN sed -i "s/{{TIME}}/$(echo ${TIME})/g" ./index.html
+
+ENTRYPOINT [ "sh", "/home/entrypoint.sh" ]

--- a/maintenance/entrypoint.sh
+++ b/maintenance/entrypoint.sh
@@ -1,4 +1,4 @@
 #! /bin/sh
 sed -i "s/{{time}}/${TIME}/g" ./index.html
 
-/bin/httpd -f -v -p 3000 -c httpd.conf
+/bin/httpd -f -v -p 3000

--- a/maintenance/entrypoint.sh
+++ b/maintenance/entrypoint.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+sed -i "s/{{time}}/${TIME}/g" ./index.html
+
+/bin/httpd -f -v -p 3000 -c httpd.conf

--- a/maintenance/static/index.html
+++ b/maintenance/static/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>Site Maintenance</title>
+<style>
+  body { text-align: center; padding: 150px; }
+  h1 { font-size: 50px; }
+  body { font: 20px Helvetica, sans-serif; color: #333; }
+  article { display: block; text-align: left; width: 650px; margin: 0 auto; }
+  a { color: #dc8100; text-decoration: none; }
+  a:hover { color: #333; text-decoration: none; }
+</style>
+
+<article>
+    <h1>We&rsquo;ll be back soon!</h1>
+    <div>
+       <p>Sorry for the inconvenience but we&rsquo;re performing some maintenance {{time}}. You can find more information on our <a href="https://status.depositar.io/">status page</a>. If you need to you can always <a href="mailto:data.contact@depositar.io">contact us</a>, otherwise we&rsquo;ll be back online shortly!</p>
+        <p>&mdash; The depositar Team</p>
+    </div>
+</article>

--- a/nginx/user_conf.d/default.conf
+++ b/nginx/user_conf.d/default.conf
@@ -126,7 +126,7 @@ server {
         include /etc/nginx/conf.d/depositar_params;
     }
 
-    error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 425 426 428 429 431 451 500 501 502 503 504 505 506 507 508 510 511 /error.html;
+    error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 425 426 428 429 431 451 500 501 505 506 507 508 510 511 /error.html;
 
     # redirect server error pages to the static page /error.html
     #
@@ -137,4 +137,9 @@ server {
       root /usr/share/nginx/html;
     }
 
+    error_page 502 503 504 =503 @maintenance;
+    location @maintenance {
+        rewrite ^ /index.html break;
+        proxy_pass http://maintenance:3000;
+    }
 }


### PR DESCRIPTION
This PR adds a simple maintenance service that serves a static maintenance page when the CKAN service is down.
The time displayed on the page can be configured via  environment variable in the `docker-compose` file.