### PR TITLE
Add CI for `prod-demo` branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,13 +2,13 @@ name: Build CKAN Docker
 
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the prod-demo branch
   push:
     branches:
-      - master
+      - prod-demo
   pull_request:
     branches:
-      - master
+      - prod-demo
 
 jobs: 
   build:  
@@ -18,6 +18,8 @@ jobs:
 
     -  name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v1
+       with:
+          driver: docker # defaults to "docker-containerized"
       
     -  name: Set up QEMU
        uses: docker/setup-qemu-action@v1
@@ -37,6 +39,37 @@ jobs:
           file: ./postgresql/Dockerfile
           push: false
           tags: kowhai/ckan-docker-postgresql:test-build-only
+
+    -  name: maintenance Build
+       uses: docker/build-push-action@v2
+       with:
+          context: ./maintenance
+          file: ./maintenance/Dockerfile
+          push: false
+          tags: kowhai/ckan-docker-ckan:test-build-only
+
+    -  name: Clone ckan-base
+       uses: actions/checkout@v4
+       with:
+          repository: depositar/ckan-docker-base
+          path: ckan-docker-base
+
+    - name: Read version from VERSION file
+      run: |
+         VERSION_VALUE=$(cat "ckan-docker-base/ckan-depositar/VERSION.txt")
+         echo "Using ref $VERSION_VALUE in next steps"
+         echo "CKAN_REF=$VERSION_VALUE" >> $GITHUB_ENV
+
+    -  name: Build the ckan-base image
+       uses: docker/build-push-action@v2
+       with:
+          context: ./ckan-docker-base/ckan-depositar
+          push: false
+          build-args: |
+            CKAN_REF=${{ env.CKAN_REF }}
+            ENV=base
+          tags: |
+            depositar/ckan-base:release-data-depositar-io-py3.10
 
     -  name: CKAN build
        uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     -  name: Set up Docker Buildx
        uses: docker/setup-buildx-action@v1
        with:
-          driver: docker # defaults to "docker-containerized"
+          driver: docker # defaults to "docker-container"
       
     -  name: Set up QEMU
        uses: docker/setup-qemu-action@v1
@@ -40,7 +40,7 @@ jobs:
           push: false
           tags: kowhai/ckan-docker-postgresql:test-build-only
 
-    -  name: maintenance Build
+    -  name: Maintenance build
        uses: docker/build-push-action@v2
        with:
           context: ./maintenance
@@ -53,6 +53,8 @@ jobs:
        with:
           repository: depositar/ckan-docker-base
           path: ckan-docker-base
+
+    # From https://github.com/ckan/ckan-docker-base/blob/main/.github/workflows/reusable-build-and-test.yml
 
     - name: Read version from VERSION file
       run: |


### PR DESCRIPTION
This PR modifies the upstream workflow to build depositar CKAN Docker images on push or pull request to the `prod-demo`　branch.
The steps for building the ckan-base image can be found [here](https://github.com/depositar/ckan-docker-base/blob/6ab6abe76d9860af9b58e12acbe845805c9e1852/.github/workflows/reusable-build-and-test.yml#L45:L63).